### PR TITLE
Fix PHPUnit tests pipeline

### DIFF
--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           php-version: '${{ inputs.php }}'
           tools: phpunit-polyfills
+          extensions: zip
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
 
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
- Run PHPUnit tests pipeline with zip extension for all Windows versions.
- No longer run the pipeline with php 7.0 and 7.1.